### PR TITLE
Add icebergs testsuite and fix model to pass testsuite

### DIFF
--- a/src/core_seaice/Registry.xml
+++ b/src/core_seaice/Registry.xml
@@ -1828,17 +1828,27 @@
 			<var name="mobileFraction"/>
 			<var name="newlyFormedIce"/>
 			<var name="maximumIcePresence"/>
-			<var name="bergAreaCategory"/>
-			<var name="bergMassCategory"/>
-			<var name="bergLength"/>
-			<var name="bergHeight"/>
-			<var name="uBergVelocity"/>
-			<var name="vBergVelocity"/>
 			<var name="testArrayRegression"/>
 			<var name="testArrayParallelism"/>
 			<var name="testArrayRestartability"/>
 			<var name="forcingGroupNames"/>
 			<var name="forcingGroupRestartTimes"/>
+			<var name="bergAreaCategory"/>
+			<var name="bergLength"/>
+			<var name="bergHeight"/>
+			<var name="bergAreaCell"/>
+			<var name="bergMassCategory"/>
+			<var name="bergMassCell"/>
+			<var name="uBergVelocity"/>
+			<var name="vBergVelocity"/>
+			<var name="bergVelocityTimeStep"/>
+			<var name="bergAdvectionTimeStep"/>
+			<var name="bergCalvingMask"/>
+			<var name="bergCalvingMass"/>
+			<var name="bergCalvingFlux"/>
+			<var name="bergCalvingDistribution"/>
+			<var name="bergCalvingLength"/>
+			<var name="bergCalvingHeight"/>
 		</stream>
 
 		<stream name="restart"
@@ -3970,7 +3980,7 @@
 	<!-- iceberg velocity solver -->
 	<var_struct name="berg_velocity_solver" time_levs="1" packages="pkgBergs">
 		<var name="bergVelocityTimeStep"		type="real"		dimensions=""								name_in_code="bergVelocityTimeStep"			units="s"		packages="pkgBergs"/>
-		<var name="bergAdvectionTimeStep"		type="real"		dimensions=""								name_in_code="bergAdvectionTimeStep"			units="s"		packages="pkgBergs"/>
+		<var name="bergAdvectionTimeStep"		type="real"		dimensions=""								name_in_code="bergAdvectionTimeStep"		units="s"		packages="pkgBergs"/>
 		<var name="uBergVelocity"				type="real"		dimensions="nBergCategories nVertices Time"	name_in_code="uBergVelocity"				units="m/s"		packages="pkgBergs"/>
 		<var name="vBergVelocity"				type="real"		dimensions="nBergCategories nVertices Time"	name_in_code="vBergVelocity"				units="m/s"		packages="pkgBergs"/>
 		<var name="uBergVelocityCell"			type="real"		dimensions="nBergCategories nCells Time"	name_in_code="uBergVelocityCell"			units="m/s"		packages="pkgBergs"/>
@@ -3994,12 +4004,12 @@
 		<var name="uAirVelocityVertex"			type="real"		dimensions="nVertices Time"					name_in_code="uAirVelocityVertex"			units="m/s"		packages="pkgBergs"/>
 		<var name="vAirVelocityVertex"			type="real"		dimensions="nVertices Time"					name_in_code="vAirVelocityVertex"			units="m/s"		packages="pkgBergs"/>
 		<var name="airDensityVertex"			type="real"		dimensions="nVertices Time"					name_in_code="airDensityVertex"				units="kg/m^3"	packages="pkgBergs"/>
-		<var name="bergAreaVertex"	type="real"		dimensions="nBergCategories nVertices Time"	name_in_code="bergAreaVertex"		units="m^2"		packages="pkgBergs"/>
-		<var name="bergLengthVertex"	type="real"		dimensions="nBergCategories nVertices Time"	name_in_code="bergLengthVertex"		units="m"		packages="pkgBergs"/>
-		<var name="bergCoefForIceU"	type="real"		dimensions="nBergCategories nVertices Time"	name_in_code="bergCoefForIceU"		units="kg*m/s^2"		packages="pkgBergs"/>
-		<var name="bergCoefForIceV"	type="real"		dimensions="nBergCategories nVertices Time"	name_in_code="bergCoefForIceV"		units="kg*m/s^2"		packages="pkgBergs"/>
-		<var name="bergStressU"	type="real"		dimensions="nVertices Time"	name_in_code="bergStressU"		units="kg*m/s^2"		packages="pkgBergs"/>
-		<var name="bergStressV"	type="real"		dimensions="nVertices Time"	name_in_code="bergStressV"		units="kg*m/s^2"		packages="pkgBergs"/>
+		<var name="bergAreaVertex"				type="real"		dimensions="nBergCategories nVertices Time"	name_in_code="bergAreaVertex"				units="m^2"		packages="pkgBergs"/>
+		<var name="bergLengthVertex"			type="real"		dimensions="nBergCategories nVertices Time"	name_in_code="bergLengthVertex"				units="m"		packages="pkgBergs"/>
+		<var name="bergCoefForIceU"				type="real"		dimensions="nBergCategories nVertices Time"	name_in_code="bergCoefForIceU"				units="kg*m/s^2"	packages="pkgBergs"/>
+		<var name="bergCoefForIceV"				type="real"		dimensions="nBergCategories nVertices Time"	name_in_code="bergCoefForIceV"				units="kg*m/s^2"	packages="pkgBergs"/>
+		<var name="bergStressU"					type="real"		dimensions="nVertices Time"					name_in_code="bergStressU"					units="kg*m/s^2"	packages="pkgBergs"/>
+		<var name="bergStressV"					type="real"		dimensions="nVertices Time"					name_in_code="bergStressV"					units="kg*m/s^2"	packages="pkgBergs"/>
 		<var name="bergCoefAtmU"				type="real"		dimensions="nBergCategories nVertices Time"	name_in_code="bergCoefAtmU"					units="kg*m/s^2"	packages="pkgBergs"/>
 		<var name="bergCoefAtmV"				type="real"		dimensions="nBergCategories nVertices Time"	name_in_code="bergCoefAtmV"					units="kg*m/s^2"	packages="pkgBergs"/>
 		<var name="bergCoefOcnU"				type="real"		dimensions="nBergCategories nVertices Time"	name_in_code="bergCoefOcnU"					units="kg*m/s^2"	packages="pkgBergs"/>

--- a/src/core_seaice/Registry.xml
+++ b/src/core_seaice/Registry.xml
@@ -1841,8 +1841,6 @@
 			<var name="bergMassCell"/>
 			<var name="uBergVelocity"/>
 			<var name="vBergVelocity"/>
-			<var name="bergVelocityTimeStep"/>
-			<var name="bergAdvectionTimeStep"/>
 			<var name="bergCalvingMask"/>
 			<var name="bergCalvingMass"/>
 			<var name="bergCalvingFlux"/>

--- a/src/core_seaice/shared/mpas_seaice_berg_decay.F
+++ b/src/core_seaice/shared/mpas_seaice_berg_decay.F
@@ -387,7 +387,7 @@ contains
          nCellsSolve, &
          nBergCategories
 
-    real, pointer :: &
+    real(kind=RKIND), pointer :: &
          bergTemperature ! berg temperature, assumed constant
 
     integer :: &

--- a/src/core_seaice/shared/mpas_seaice_berg_velocity_solver.F
+++ b/src/core_seaice/shared/mpas_seaice_berg_velocity_solver.F
@@ -63,6 +63,42 @@ contains
     type(block_type), pointer :: &
          block
 
+    logical, pointer :: &
+         config_do_restart
+
+    call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
+
+    ! set timesteps and initialize velocities
+    block => domain % blocklist
+    do while (associated(block))
+
+       ! calculate berg timesteps
+       call init_berg_timesteps(block)
+
+       ! if initial run, initialize berg velocities
+       if (.not. config_do_restart) call init_berg_velocity(block)
+
+       block => block % next
+    enddo
+
+  end subroutine seaice_init_berg_velocity_solver
+
+!|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
+!
+!  init_berg_timesteps
+!
+!> \brief   Initialize berg timesteps
+!> \author  Darin Comeau, LANL
+!> \date    Aug 3, 2018
+!> \details This subroutine initializes iceberg timesteps.
+!
+!-----------------------------------------------------------------------
+
+  subroutine init_berg_timesteps(block)
+
+    type(block_type), intent(inout) :: &
+         block
+
     type(MPAS_pool_type), pointer :: &
          bergVelocitySolverPool
 
@@ -76,45 +112,33 @@ contains
          config_berg_velocity_subcycle_number ! berg subcycling number
 
     logical, pointer :: &
-         config_do_restart, &
          config_berg_advection_outside_velocity_subcycling
 
-    call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
+    call MPAS_pool_get_config(block % configs, "config_dt", config_dt)
+    call MPAS_pool_get_config(block % configs, "config_dynamics_subcycle_number", config_dynamics_subcycle_number)
+    call MPAS_pool_get_config(block % configs, "config_berg_velocity_subcycle_number", config_berg_velocity_subcycle_number)
+    call MPAS_pool_get_config(block % configs, "config_berg_advection_outside_velocity_subcycling", config_berg_advection_outside_velocity_subcycling)
 
-    ! set timesteps and initialize velocities
-    block => domain % blocklist
-    do while (associated(block))
+    call MPAS_pool_get_subpool(block % structs, "berg_velocity_solver", bergVelocitySolverPool)
+    call MPAS_pool_get_array(bergVelocitySolverPool, "bergVelocityTimeStep", bergVelocityTimeStep)
+    call MPAS_pool_get_array(bergVelocitySolverPool, "bergAdvectionTimeStep", bergAdvectionTimeStep)
 
-       call MPAS_pool_get_config(block % configs, "config_dt", config_dt)
-       call MPAS_pool_get_config(block % configs, "config_dynamics_subcycle_number", config_dynamics_subcycle_number)
-       call MPAS_pool_get_config(block % configs, "config_berg_velocity_subcycle_number", config_berg_velocity_subcycle_number)
-       call MPAS_pool_get_config(block % configs, "config_berg_advection_outside_velocity_subcycling", config_berg_advection_outside_velocity_subcycling)
+    ! berg velocity solver is inside sea ice dynamics loop in seaice_time_integration
+    bergVelocityTimeStep = config_dt / (real(config_berg_velocity_subcycle_number,RKIND) * &
+                                        real(config_dynamics_subcycle_number,RKIND))
 
-       call MPAS_pool_get_subpool(block % structs, "berg_velocity_solver", bergVelocitySolverPool)
-       call MPAS_pool_get_array(bergVelocitySolverPool, "bergVelocityTimeStep", bergVelocityTimeStep)
-       call MPAS_pool_get_array(bergVelocitySolverPool, "bergAdvectionTimeStep", bergAdvectionTimeStep)
+    if (config_berg_advection_outside_velocity_subcycling) then
 
-       ! berg velocity solver is inside sea ice dynamics loop in seaice_time_integration
-       bergVelocityTimeStep = config_dt / (real(config_berg_velocity_subcycle_number,RKIND) * &
-                                           real(config_dynamics_subcycle_number,RKIND))
+      ! berg advection is inside sea ice dynamics loop in seaice_time_integration
+      bergAdvectionTimeStep = config_dt / (real(config_dynamics_subcycle_number,RKIND))
 
-       if (config_berg_advection_outside_velocity_subcycling) then
+    else ! advection inside subcycling, advection timestep same as velocity solver timestep
 
-          ! berg advection is inside sea ice dynamics loop in seaice_time_integration
-          bergAdvectionTimeStep = config_dt / (real(config_dynamics_subcycle_number,RKIND))
+      bergAdvectionTimeStep = bergVelocityTimeStep
 
-       else ! advection inside subcycling, advection timestep same as velocity solver timestep
+    endif ! config_berg_advection_outside_velocity_subcycling
 
-          bergAdvectionTimeStep = bergVelocityTimeStep
-
-       endif ! config_berg_advection_outside_velocity_subcycling
-
-       if (.not. config_do_restart) call init_berg_velocity(block)
-
-       block => block % next
-    enddo
-
-  end subroutine seaice_init_berg_velocity_solver
+  end subroutine init_berg_timesteps
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 !

--- a/src/core_seaice/shared/mpas_seaice_berg_velocity_solver.F
+++ b/src/core_seaice/shared/mpas_seaice_berg_velocity_solver.F
@@ -295,12 +295,6 @@ contains
 
     endif
 
-    ! halo exchange
-    call mpas_timer_start("Berg velocity solver halo")
-    call MPAS_dmpar_field_halo_exch(domain, 'uBergVelocity')
-    call MPAS_dmpar_field_halo_exch(domain, 'vBergVelocity')
-    call mpas_timer_stop("Berg velocity solver halo")
-
   end subroutine seaice_run_berg_velocity_solver
 
 !|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
@@ -443,6 +437,11 @@ contains
     integer :: &
          iCategory
 
+    ! halo exchange
+    call mpas_timer_start("Berg velocity solver halo")
+    call MPAS_dmpar_field_halo_exch(domain, 'bergMassCategory')
+    call mpas_timer_stop("Berg velocity solver halo")
+
     ! interpolate area and mass from cells to vertices
     block => domain % blocklist
     do while (associated(block))
@@ -469,13 +468,13 @@ contains
        block => block % next
     end do
 
+    ! halo exchange
+    call mpas_timer_start("Berg velocity solver halo")
+    call MPAS_dmpar_field_halo_exch(domain, 'bergMassVertex')
+    call mpas_timer_stop("Berg velocity solver halo")
+
     ! calculate computational masks
     call berg_velocity_calculation_mask(domain)
-
-    ! halo exchange velocity mask
-    call mpas_timer_start("berg velocity mask halo")
-    call MPAS_dmpar_field_halo_exch(domain, 'bergVelocityMask')
-    call mpas_timer_stop("berg velocity mask halo")
 
   end subroutine berg_calculation_masks
 
@@ -814,6 +813,40 @@ contains
 
        enddo ! iCell
 
+       block => block % next
+    enddo ! block
+
+    ! halo exchanges for interpolated quantities
+    call mpas_timer_start("Berg velocity solver halo")
+    call MPAS_dmpar_field_halo_exch(domain, 'bergDraft')
+    call MPAS_dmpar_field_halo_exch(domain, 'oneBergArea')
+    call MPAS_dmpar_field_halo_exch(domain, 'oneBergMass')
+    call MPAS_dmpar_field_halo_exch(domain, 'bergAirContactArea')
+    call MPAS_dmpar_field_halo_exch(domain, 'bergOcnContactArea')
+    call MPAS_dmpar_field_halo_exch(domain, 'bergIceContactArea')
+    call mpas_timer_stop("Berg velocity solver halo")
+
+    block => domain % blocklist
+    do while (associated(block))
+
+       call MPAS_pool_get_dimension(block % dimensions, "nCellsSolve", nCellsSolve)
+       call MPAS_pool_get_dimension(block % dimensions, "nBergCategories", nBergCategories)
+
+       call MPAS_pool_get_subpool(block % structs, "berg_velocity_solver", bergVelocityPool)
+
+       call MPAS_pool_get_array(bergVelocityPool, "bergDraft", bergDraft)
+       call MPAS_pool_get_array(bergVelocityPool, "oneBergArea", oneBergArea)
+       call MPAS_pool_get_array(bergVelocityPool, "oneBergMass", oneBergMass)
+       call MPAS_pool_get_array(bergVelocityPool, "bergDraftVertex", bergDraftVertex)
+       call MPAS_pool_get_array(bergVelocityPool, "oneBergAreaVertex", oneBergAreaVertex)
+       call MPAS_pool_get_array(bergVelocityPool, "oneBergMassVertex", oneBergMassVertex)
+       call MPAS_pool_get_array(bergVelocityPool, "bergAirContactArea", bergAirContactArea)
+       call MPAS_pool_get_array(bergVelocityPool, "bergOcnContactArea", bergOcnContactArea)
+       call MPAS_pool_get_array(bergVelocityPool, "bergIceContactArea", bergIceContactArea)
+       call MPAS_pool_get_array(bergVelocityPool, "bergAirContactAreaVertex", bergAirContactAreaVertex)
+       call MPAS_pool_get_array(bergVelocityPool, "bergOcnContactAreaVertex", bergOcnContactAreaVertex)
+       call MPAS_pool_get_array(bergVelocityPool, "bergIceContactAreaVertex", bergIceContactAreaVertex)
+
        do iCategory = 1, nBergCategories
 
           ! interpolate from cells to vertices
@@ -847,10 +880,20 @@ contains
              bergIceContactAreaVertex(iCategory,:), &
              bergIceContactArea(iCategory,:))
 
-          enddo
+       enddo
 
        block => block % next
-    end do ! block
+    enddo ! block
+
+    ! halo exchanges for interpolated quantities
+    call mpas_timer_start("Berg velocity solver halo")
+    call MPAS_dmpar_field_halo_exch(domain, 'bergDraftVertex')
+    call MPAS_dmpar_field_halo_exch(domain, 'oneBergAreaVertex')
+    call MPAS_dmpar_field_halo_exch(domain, 'oneBergMassVertex')
+    call MPAS_dmpar_field_halo_exch(domain, 'bergAirContactAreaVertex')
+    call MPAS_dmpar_field_halo_exch(domain, 'bergOcnContactAreaVertex')
+    call MPAS_dmpar_field_halo_exch(domain, 'bergIceContactAreaVertex')
+    call mpas_timer_stop("Berg velocity solver halo")
 
   end subroutine berg_vertical_areas
 
@@ -1014,6 +1057,13 @@ contains
          airVertDragCoef = 0.2_RKIND, &
          airHorizDragCoef = 0.00025_RKIND
 
+    ! halo exchange
+    call mpas_timer_start("Berg velocity solver halo")
+    call MPAS_dmpar_field_halo_exch(domain, 'uAirVelocity')
+    call MPAS_dmpar_field_halo_exch(domain, 'vAirVelocity')
+    call MPAS_dmpar_field_halo_exch(domain, 'airDensity')
+    call mpas_timer_stop("Berg velocity solver halo")
+
     block => domain % blocklist
     do while (associated(block))
 
@@ -1150,6 +1200,12 @@ contains
          ocnVertDragCoef = 0.425_RKIND, &
          ocnHorizDragCoef = 0.0005_RKIND
 
+    ! halo exchange
+    call mpas_timer_start("Berg velocity solver halo")
+    call MPAS_dmpar_field_halo_exch(domain, 'uOceanVelocity')
+    call MPAS_dmpar_field_halo_exch(domain, 'vOceanVelocity')
+    call mpas_timer_stop("Berg velocity solver halo")
+
     block => domain % blocklist
     do while (associated(block))
 
@@ -1213,7 +1269,7 @@ contains
        enddo ! iVertex
 
        block => block % next
-    end do
+    enddo
 
   end subroutine berg_ocn_forcing
 
@@ -1513,6 +1569,12 @@ contains
          iVertex, &
          iCategory
 
+    ! halo exchange
+    call mpas_timer_start("Berg velocity solver halo")
+    call MPAS_dmpar_field_halo_exch(domain, 'seaSurfaceTiltU')
+    call MPAS_dmpar_field_halo_exch(domain, 'seaSurfaceTiltU')
+    call mpas_timer_stop("Berg velocity solver halo")
+
     block => domain % blocklist
     do while (associated(block))
 
@@ -1565,7 +1627,7 @@ contains
        enddo ! iVertex
 
        block => block % next
-    end do
+    enddo
 
   end subroutine berg_tlt_forcing
 
@@ -1627,6 +1689,7 @@ contains
          nVerticesSolve, &
          nBergCategories
 
+    ! local variables
     integer :: &
          iVertex, &
          iCategory
@@ -1634,6 +1697,7 @@ contains
     real(kind=RKIND) :: &
          rightSideU, &
          rightSideV
+
 
     block => domain % blocklist
     do while (associated(block))
@@ -1668,6 +1732,9 @@ contains
        do iVertex = 1, nVerticesSolve
 
           do iCategory = 1, nBergCategories
+
+             rightSideU = 0.0_RKIND
+             rightSideV = 0.0_RKIND
 
              ! check if velocity should be solved
              if (bergVelocityMask(iCategory,iVertex) == 1 .and. oneBergMassVertex(iCategory,iVertex) > seaicePuny) then
@@ -1811,6 +1878,7 @@ contains
 
     call MPAS_pool_get_config(domain % configs, "config_berg_density", bergDensity)
 
+
     block => domain % blocklist
     do while (associated(block))
 
@@ -1939,11 +2007,6 @@ contains
 
        block => block % next
     enddo
-
-    ! halo exchange
-    call mpas_timer_start("Berg velocity solver halo")
-    call MPAS_dmpar_field_halo_exch(domain, 'bergDisplacedArea')
-    call mpas_timer_stop("Berg velocity solver halo")  
 
   end subroutine seaice_berg_forcing_for_ice
 

--- a/src/core_seaice/shared/mpas_seaice_berg_velocity_solver.F
+++ b/src/core_seaice/shared/mpas_seaice_berg_velocity_solver.F
@@ -76,7 +76,10 @@ contains
          config_berg_velocity_subcycle_number ! berg subcycling number
 
     logical, pointer :: &
+         config_do_restart, &
          config_berg_advection_outside_velocity_subcycling
+
+    call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
 
     ! set timesteps and initialize velocities
     block => domain % blocklist
@@ -106,7 +109,7 @@ contains
 
        endif ! config_berg_advection_outside_velocity_subcycling
 
-       call init_berg_velocity(block)
+       if (.not. config_do_restart) call init_berg_velocity(block)
 
        block => block % next
     enddo
@@ -1061,7 +1064,6 @@ contains
     call mpas_timer_start("Berg velocity solver halo")
     call MPAS_dmpar_field_halo_exch(domain, 'uAirVelocity')
     call MPAS_dmpar_field_halo_exch(domain, 'vAirVelocity')
-    call MPAS_dmpar_field_halo_exch(domain, 'airDensity')
     call mpas_timer_stop("Berg velocity solver halo")
 
     block => domain % blocklist

--- a/src/core_seaice/shared/mpas_seaice_bergs.F
+++ b/src/core_seaice/shared/mpas_seaice_bergs.F
@@ -87,6 +87,9 @@ contains
     ! restart run
     elseif (config_use_bergs .and. config_do_restart) then
 
+       ! initialize velocity solver
+       call seaice_init_berg_velocity_solver(domain)
+
        ! tracers still need to be initialized in restarts
        call seaice_init_berg_tracers(domain)
 

--- a/src/core_seaice/shared/mpas_seaice_bergs.F
+++ b/src/core_seaice/shared/mpas_seaice_bergs.F
@@ -62,11 +62,14 @@ contains
          domain !< Input/Output:
 
     logical, pointer :: &
-         config_use_bergs ! flag to turn on / off iceberg model
+         config_use_bergs, & ! flag to turn on / off iceberg model
+         config_do_restart   ! flag if restart
 
     call MPAS_pool_get_config(domain % configs, "config_use_bergs", config_use_bergs)
+    call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
 
-    if (config_use_bergs) then
+    ! initial run
+    if (config_use_bergs .and. .not. config_do_restart) then
 
        call mpas_timer_start("Berg initialization")
 
@@ -80,6 +83,12 @@ contains
        call seaice_init_berg_tracers(domain)
 
        call mpas_timer_stop("Berg initialization")
+
+    ! restart run
+    elseif (config_use_bergs .and. config_do_restart) then
+
+       ! tracers still need to be initialized in restarts
+       call seaice_init_berg_tracers(domain)
 
     endif
 

--- a/src/core_seaice/shared/mpas_seaice_bergs.F
+++ b/src/core_seaice/shared/mpas_seaice_bergs.F
@@ -68,13 +68,18 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_use_bergs", config_use_bergs)
     call MPAS_pool_get_config(domain % configs, "config_do_restart", config_do_restart)
 
-    ! initial run
-    if (config_use_bergs .and. .not. config_do_restart) then
+
+    if (config_use_bergs) then
 
        call mpas_timer_start("Berg initialization")
 
-       ! initialize calving fluxes
-       call seaice_init_berg_calving_fluxes(domain)
+       ! initial run
+       if (.not. config_do_restart) then
+
+          ! initialize calving fluxes
+          call seaice_init_berg_calving_fluxes(domain)
+
+       endif
 
        ! initialize velocity solver
        call seaice_init_berg_velocity_solver(domain)
@@ -83,15 +88,6 @@ contains
        call seaice_init_berg_tracers(domain)
 
        call mpas_timer_stop("Berg initialization")
-
-    ! restart run
-    elseif (config_use_bergs .and. config_do_restart) then
-
-       ! initialize velocity solver
-       call seaice_init_berg_velocity_solver(domain)
-
-       ! tracers still need to be initialized in restarts
-       call seaice_init_berg_tracers(domain)
 
     endif
 

--- a/testing_and_setup/seaice/testing/testsuites/testsuite.icebergs.xml
+++ b/testing_and_setup/seaice/testing/testsuites/testsuite.icebergs.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="icebergs">
+	<configuration name="icebergs">
+		<domain name="domain_QU120km">
+			<test name="regression"/>
+			<test name="parallelism"/>
+			<test name="restartability"/>
+		</domain>
+	</configuration>
+</testsuite>


### PR DESCRIPTION
This PR adds an icebergs testsuite (regression, parallelism, and restartability) that includes the iceberg model in testing. Changes were made so that these tests pass, which they now do.

BFB in standard_physics testing (where icebergs are turned off).