### PR TITLE
Bug fix of iceberg velocity arguments.

### DIFF
--- a/src/core_seaice/shared/mpas_seaice_berg_velocity_solver.F
+++ b/src/core_seaice/shared/mpas_seaice_berg_velocity_solver.F
@@ -1973,8 +1973,8 @@ contains
 
                 ! if > 0, angle between two velocities is less than 90 degrees
                 ! if < 0, angle between two velocities is greater than 90 degrees
-                dotProductNum = uBergVelocity(iVertex, iCategory) * uVelocity(iVertex) + &
-                                vBergVelocity(iVertex, iCategory) * vVelocity(iVertex)
+                dotProductNum = uBergVelocity(iCategory, iVertex) * uVelocity(iVertex) + &
+                                vBergVelocity(iCategory, iVertex) * vVelocity(iVertex)
 
                 if (dotProductNum < 0.0_RKIND) then
                 ! bergs and sea ice are moving in opposing direction, sea ice has additional term in


### PR DESCRIPTION
The ordering of iCategory, iVertex arguments was reversed in one set of iceberg velocity calls. Note the relevant quantity being calculated with this bug is not actually used yet (it's use is in [PR #2 ](https://github.com/darincomeau/MPAS-Model/pull/2)).

Passes standard_physics and icebergs testsuites.

