### PR TITLE
Moving berg_mass_threshold from private parameter to namelist option.

### DIFF
--- a/src/core_seaice/Registry.xml
+++ b/src/core_seaice/Registry.xml
@@ -1671,6 +1671,7 @@
 		<nml_option name="config_berg_initial_vvelocity_geo"	type="real"		default_value="0.0"/>
 		<nml_option name="config_use_berg_velocity_solver"	type="logical"		default_value="false"/>
 		<nml_option name="config_berg_velocity_subcycle_number"		type="integer"		default_value="30"		possible_values="any positive integer"/>
+		<nml_option name="config_berg_mass_threshold"		type="real"		default_value="1.0"		units="kg"/>
 		<nml_option name="config_berg_ice_concentration_threshold"	type="real"		default_value="0.9"/>
 		<nml_option name="config_berg_ice_min_concentration_threshold"	type="real"		default_value="0.15"/>
 		<nml_option name="config_berg_ice_strength_threshold"		type="real"		default_value="1000.0"/>

--- a/src/core_seaice/shared/mpas_seaice_berg_state.F
+++ b/src/core_seaice/shared/mpas_seaice_berg_state.F
@@ -784,7 +784,7 @@ contains
        call MPAS_pool_get_subpool(block % structs, "berg_state", bergStatePool)
        call MPAS_pool_get_array(bergStatePool, "bergDisplacedArea", bergDisplacedArea)
 
-       bergDisplacedArea (:) = 0.0_RKIND
+       bergDisplacedArea(:) = 0.0_RKIND
 
     block => block % next
     enddo

--- a/src/core_seaice/shared/mpas_seaice_berg_velocity_solver.F
+++ b/src/core_seaice/shared/mpas_seaice_berg_velocity_solver.F
@@ -33,10 +33,6 @@ module seaice_berg_velocity_solver
        seaice_run_berg_velocity_solver, &
        seaice_berg_forcing_for_ice
 
-  ! berg velocity solver constants
-  real(kind=RKIND), parameter, private :: &
-       bergMassMinimum = 0.01_RKIND
-
 contains
 
 !-----------------------------------------------------------------------
@@ -553,6 +549,7 @@ contains
          cellsOnVertex
 
     real(kind=RKIND), pointer :: &
+         config_berg_mass_threshold, & ! mass threshold for velocity solver
          config_berg_ice_concentration_threshold, & ! ice concentration threshold for capture
          config_berg_ice_strength_threshold         ! ice strength threshold for capture
 
@@ -568,6 +565,7 @@ contains
          nBergCategories, &
          vertexDegree
 
+    call MPAS_pool_get_config(domain % configs, "config_berg_mass_threshold", config_berg_mass_threshold)
     call MPAS_pool_get_config(domain % configs, "config_berg_ice_concentration_threshold", config_berg_ice_concentration_threshold)
     call MPAS_pool_get_config(domain % configs, "config_berg_ice_strength_threshold", config_berg_ice_strength_threshold)
 
@@ -606,7 +604,7 @@ contains
 
              if (interiorVertex(iVertex) == 1 .and. &
                 landIceMaskVertex(iVertex) == 0 .and. &
-                bergMassVertex(iCategory,iVertex) > bergMassMinimum) then
+                bergMassVertex(iCategory,iVertex) > config_berg_mass_threshold) then
 
                 ! this vertex has sufficient ice
                 bergVelocityMask(iCategory,iVertex) = 1
@@ -712,6 +710,7 @@ contains
          config_berg_horizontal_shape ! check horizontal shape assumption (tabular or cylindrical)
 
     real(kind=RKIND), pointer :: &
+         config_berg_mass_threshold, & ! mass threshold for velocity solver
          bergDensity ! berg density (kg/m^3)
 
     integer, pointer :: &
@@ -738,6 +737,7 @@ contains
          tabularToCylindricalConvFactor = 2.0_RKIND*sqrt(2.0_RKIND/(3.0_RKIND*pii))
 
     call MPAS_pool_get_config(domain % configs, "config_berg_horizontal_shape", config_berg_horizontal_shape)
+    call MPAS_pool_get_config(domain % configs, "config_berg_mass_threshold", config_berg_mass_threshold)
     call MPAS_pool_get_config(domain % configs, "config_berg_density", bergDensity)
 
     block => domain % blocklist
@@ -796,7 +796,7 @@ contains
 
           do iCategory = 1, nBergCategories
 
-          if (bergMassCategory(iCategory,iCell) > bergMassMinimum) then
+          if (bergMassCategory(iCategory,iCell) > config_berg_mass_threshold) then
 
              seaIceDraft = (seaiceDensitySnow*seaIceSnow + seaiceDensityIce*seaIceThick)/seaiceDensitySeaWater
 

--- a/testing_and_setup/seaice/configurations/icebergs/namelist.seaice
+++ b/testing_and_setup/seaice/configurations/icebergs/namelist.seaice
@@ -333,6 +333,7 @@
     config_berg_initial_vvelocity_geo = 0.0
     config_use_berg_velocity_solver = true
     config_berg_velocity_subcycle_number = 30
+    config_berg_mass_threshold = 0.01
     config_berg_ice_concentration_threshold = 0.9
     config_berg_ice_min_concentration_threshold = 0.15
     config_berg_ice_strength_threshold = 1000.0

--- a/testing_and_setup/seaice/configurations/icebergs/namelist.seaice
+++ b/testing_and_setup/seaice/configurations/icebergs/namelist.seaice
@@ -333,7 +333,7 @@
     config_berg_initial_vvelocity_geo = 0.0
     config_use_berg_velocity_solver = true
     config_berg_velocity_subcycle_number = 30
-    config_berg_mass_threshold = 0.01
+    config_berg_mass_threshold = 1.0
     config_berg_ice_concentration_threshold = 0.9
     config_berg_ice_min_concentration_threshold = 0.15
     config_berg_ice_strength_threshold = 1000.0

--- a/testing_and_setup/seaice/configurations/icebergs/streams.seaice
+++ b/testing_and_setup/seaice/configurations/icebergs/streams.seaice
@@ -33,8 +33,17 @@
         filename_template="output/output.$Y.nc"
         filename_interval="01-00-00_00:00:00"
         clobber_mode="replace_files"
-        output_interval="none" >
-
+        output_interval="00-01-00_00:00:00" >
+	<var name="xtime"/>
+	<var name="daysSinceStartOfSim"/>
+	<var name="iceAreaCell"/>
+	<var name="iceVolumeCell"/>
+	<var name="snowVolumeCell"/>
+	<var name="uVelocityGeo"/>
+	<var name="vVelocityGeo"/>
+	<var name="bergAreaCell"/>
+	<var name="bergMassCell"/>
+	<var name="bergFreshwaterFluxCell"/>
 </stream>
 
 <immutable_stream name="LYqSixHourlyForcing"
@@ -69,10 +78,10 @@
         clobber_mode="truncate"
         output_interval="none" >
 
-  <stream name="mesh"/>
-  <stream name="abort_contents"/>
-  <var name="daysSinceStartOfSim"/>
-  <var name="xtime"/>
+	<stream name="mesh"/>
+	<stream name="abort_contents"/>
+	<var name="daysSinceStartOfSim"/>
+	<var name="xtime"/>
 </stream>
 
 <stream name="abort"
@@ -82,10 +91,10 @@
         clobber_mode="truncate"
         output_interval="none" >
 
-  <stream name="mesh"/>
-  <stream name="abort_contents"/>
-  <var name="daysSinceStartOfSim"/>
-  <var name="xtime"/>
+	<stream name="mesh"/>
+	<stream name="abort_contents"/>
+	<var name="daysSinceStartOfSim"/>
+	<var name="xtime"/>
 </stream>
 
 <stream name="regionalStatisticsOutput"
@@ -201,8 +210,8 @@
         reference_time="0000-01-01_00:00:00"
         clobber_mode="truncate"
         packages="timeSeriesStatsMonthlyAMPKG"
-        input_interval="initial_only"
-        output_interval="stream:restart:output_interval" >
+        input_interval="none"
+        output_interval="none" >
 
 </stream>
 
@@ -269,8 +278,8 @@
 	<var name="meltPondDepthFinalArea"/>
 	<var name="meltPondLidThicknessFinalArea"/>
 	<var name="bergAreaCell"/>
-	<var name="bergFreshwaterFluxCell"/>
 	<var name="bergMassCell"/>
+	<var name="bergFreshwaterFluxCell"/>
 
 </stream>
 

--- a/testing_and_setup/seaice/configurations/standard_physics/namelist.seaice
+++ b/testing_and_setup/seaice/configurations/standard_physics/namelist.seaice
@@ -333,6 +333,7 @@
     config_berg_initial_vvelocity_geo = 0.0
     config_use_berg_velocity_solver = false
     config_berg_velocity_subcycle_number = 30
+    config_berg_mass_threshold = 1.0
     config_berg_ice_concentration_threshold = 0.9
     config_berg_ice_min_concentration_threshold = 0.15
     config_berg_ice_strength_threshold = 1000.0


### PR DESCRIPTION
This PR moves the private parameter bergMassMinimum in mpas_seaice_berg_velocity_solver.F to a namelist option berg_mass_threshold, and raises the default option from 0.01 kg to 1kg.

Changes to the icebergs streams.seaice file are also made to make it closer to the standard_physics streams.seaice file.

[BFB] for standard_physics testsuite

[BFB] for parallelism and restartability tests in icebergs testsuite. [non-BFB] in iceberg variables only for regression test, due to the default change of berg_mass_threshold (as expected). When berg_mass_threshold is set to the previous value of 0.01, [BFB] for regression test.
