### PR TITLE
Rename berg fluxes

### DIFF
--- a/src/core_seaice/Registry.xml
+++ b/src/core_seaice/Registry.xml
@@ -4032,10 +4032,10 @@
 
 	<!-- icebergs fluxes -->
 	<var_struct name="berg_fluxes" time_levs="1" packages="pkgBergs">
+		<var name="bergFreshwaterFlux"			type="real"	dimensions="nCells Time"					name_in_code="bergFreshwaterFlux"		units="kg/m^2/s"	packages="pkgBergs"/>
+		<var name="bergLatentHeatFlux"			type="real"	dimensions="nCells Time"					name_in_code="bergLatentHeatFlux"		units="J/m^2/s"		packages="pkgBergs"/>
 		<var name="bergFreshwaterFluxCategory"	type="real"	dimensions="nBergCategories nCells Time"	name_in_code="bergFreshwaterFluxCategory"	units="kg/m^2/s"	packages="pkgBergs"/>
 		<var name="bergLatentHeatFluxCategory"	type="real"	dimensions="nBergCategories nCells Time"	name_in_code="bergLatentHeatFluxCategory"	units="J/m^2/s"		packages="pkgBergs"/>
-		<var name="bergFreshwaterFluxCell"		type="real"	dimensions="nCells Time"					name_in_code="bergFreshwaterFluxCell"		units="kg/m^2/s"	packages="pkgBergs"/>
-		<var name="bergLatentHeatFluxCell"		type="real"	dimensions="nCells Time"					name_in_code="bergLatentHeatFluxCell"		units="J/m^2/s"		packages="pkgBergs"/>
 	</var_struct>
 
 #include "analysis_members/Registry_seaice_analysis_members.xml"

--- a/src/core_seaice/shared/mpas_seaice_berg_decay.F
+++ b/src/core_seaice/shared/mpas_seaice_berg_decay.F
@@ -135,8 +135,8 @@ contains
          bergLatentHeatFluxCategory    ! latent heat flux due to berg decay (J/m^2/s)
 
     real(kind=RKIND), dimension (:), pointer :: &
-         bergFreshwaterFluxCell, & ! aggregate freshwater flux (kg/m^2/s)
-         bergLatentHeatFluxCell    ! aggregate latent heat flux (J/m^2/s)
+         bergFreshwaterFlux, & ! aggregate freshwater flux (kg/m^2/s)
+         bergLatentHeatFlux    ! aggregate latent heat flux (J/m^2/s)
 
     integer, pointer :: &
          nCellsSolve, &
@@ -160,8 +160,8 @@ contains
 
     call MPAS_pool_get_array(bergFluxesPool, "bergFreshwaterFluxCategory", bergFreshwaterFluxCategory)
     call MPAS_pool_get_array(bergFluxesPool, "bergLatentHeatFluxCategory", bergLatentHeatFluxCategory)
-    call MPAS_pool_get_array(bergFluxesPool, "bergFreshwaterFluxCell", bergFreshwaterFluxCell)
-    call MPAS_pool_get_array(bergFluxesPool, "bergLatentHeatFluxCell", bergLatentHeatFluxCell)
+    call MPAS_pool_get_array(bergFluxesPool, "bergFreshwaterFlux", bergFreshwaterFlux)
+    call MPAS_pool_get_array(bergFluxesPool, "bergLatentHeatFlux", bergLatentHeatFlux)
 
     do iCell = 1, nCellsSolve
 
@@ -178,8 +178,8 @@ contains
 
        enddo
 
-       bergFreshwaterFluxCell(iCell) = 0.0_RKIND
-       bergLatentHeatFluxCell(iCell) = 0.0_RKIND
+       bergFreshwaterFlux(iCell) = 0.0_RKIND
+       bergLatentHeatFlux(iCell) = 0.0_RKIND
 
     enddo
 
@@ -836,8 +836,8 @@ contains
 
     real(kind=RKIND), dimension(:), pointer :: &
          areaCell, &
-         bergFreshwaterFluxCell, & ! aggregate freshwater flux (kg/m^2/s)
-         bergLatentHeatFluxCell    ! aggregate latent heat flux (J/m^2/s)
+         bergFreshwaterFlux, & ! aggregate freshwater flux (kg/m^2/s)
+         bergLatentHeatFlux    ! aggregate latent heat flux (J/m^2/s)
 
     real(kind=RKIND), pointer :: &
          config_dt, &
@@ -870,8 +870,8 @@ contains
 
     call MPAS_pool_get_array(bergFluxesPool, "bergFreshwaterFluxCategory", bergFreshwaterFluxCategory)
     call MPAS_pool_get_array(bergFluxesPool, "bergLatentHeatFluxCategory", bergLatentHeatFluxCategory)
-    call MPAS_pool_get_array(bergFluxesPool, "bergFreshwaterFluxCell", bergFreshwaterFluxCell)
-    call MPAS_pool_get_array(bergFluxesPool, "bergLatentHeatFluxCell", bergLatentHeatFluxCell)
+    call MPAS_pool_get_array(bergFluxesPool, "bergFreshwaterFlux", bergFreshwaterFlux)
+    call MPAS_pool_get_array(bergFluxesPool, "bergLatentHeatFlux", bergLatentHeatFlux)
 
     do iCell = 1, nCellsSolve
 
@@ -888,8 +888,8 @@ contains
                                                          / (areaCell(iCell)*config_dt)
 
              ! aggregate quantities
-             bergFreshwaterFluxCell(iCell) = bergFreshwaterFluxCell(iCell) + bergFreshwaterFluxCategory(iCategory,iCell)
-             bergLatentHeatFluxCell(iCell) = bergLatentHeatFluxCell(iCell) + bergLatentHeatFluxCategory(iCategory,iCell)
+             bergFreshwaterFlux(iCell) = bergFreshwaterFlux(iCell) + bergFreshwaterFluxCategory(iCategory,iCell)
+             bergLatentHeatFlux(iCell) = bergLatentHeatFlux(iCell) + bergLatentHeatFluxCategory(iCategory,iCell)
 
           endif
 

--- a/testing_and_setup/seaice/configurations/icebergs/streams.seaice
+++ b/testing_and_setup/seaice/configurations/icebergs/streams.seaice
@@ -43,7 +43,7 @@
 	<var name="vVelocityGeo"/>
 	<var name="bergAreaCell"/>
 	<var name="bergMassCell"/>
-	<var name="bergFreshwaterFluxCell"/>
+	<var name="bergFreshwaterFlux"/>
 </stream>
 
 <immutable_stream name="LYqSixHourlyForcing"
@@ -279,7 +279,7 @@
 	<var name="meltPondLidThicknessFinalArea"/>
 	<var name="bergAreaCell"/>
 	<var name="bergMassCell"/>
-	<var name="bergFreshwaterFluxCell"/>
+	<var name="bergFreshwaterFlux"/>
 
 </stream>
 


### PR DESCRIPTION
This PR renames the iceberg flux variables:

bergFreshwaterFluxCell -> bergFreshwaterFlux
bergLatentHeatFluxCell -> bergLatentHeatFlux

The name changes are made to match the names used for the same variables in the data iceberg model in MPAS-Seaice and E3SM.

[BFB] Passes standard_physics and icebergs testing suites.
